### PR TITLE
Feature/add dynamic driver properties

### DIFF
--- a/config/lockdown.php
+++ b/config/lockdown.php
@@ -20,19 +20,19 @@ return [
     'guards' => [
         'config' => [
             'driver' => 'config',
-            'arguments' => [
 
+            'arguments' => [
                 'users' => [
                     [
                         'user' => 'admin',
                         'password' => 'secret',
                     ],
                 ],
-                
             ],
         ],
         'database' => [
             'driver' => 'database',
+            
             'arguments' => [
                 'group' => 'default',
             ],

--- a/config/lockdown.php
+++ b/config/lockdown.php
@@ -21,21 +21,17 @@ return [
         'config' => [
             'driver' => 'config',
 
-            'arguments' => [
-                'users' => [
-                    [
-                        'user' => 'admin',
-                        'password' => 'secret',
-                    ],
-                ],
-            ],
+            'users' => [
+                [
+                    'user' => 'admin',
+                    'password' => 'secret'
+                ]
+            ]
         ],
         'database' => [
             'driver' => 'database',
             
-            'arguments' => [
-                'group' => 'default',
-            ],
-        ],
-    ],
+            'group' => 'default'
+        ]
+    ]
 ];

--- a/config/lockdown.php
+++ b/config/lockdown.php
@@ -21,10 +21,14 @@ return [
         'config' => [
             'driver' => 'config',
             'arguments' => [
-                [
-                    'user' => 'admin',
-                    'password' => 'secret',
+
+                'users' => [
+                    [
+                        'user' => 'admin',
+                        'password' => 'secret',
+                    ],
                 ],
+                
             ],
         ],
         'database' => [

--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -2,9 +2,9 @@
 
 namespace Leuverink\Lockdown;
 
+use Illuminate\Support\Collection;
 use Leuverink\Lockdown\Drivers\Driver;
 use Leuverink\Lockdown\Exceptions\LockdownDriverNotFound;
-use Illuminate\Support\Fluent;
 
 class DriverFactory
 {
@@ -13,7 +13,7 @@ class DriverFactory
 
     public function __construct($guard)
     {
-        $this->guard = new Fluent($guard);
+        $this->guard = new Collection($guard);
     }
 
     /**
@@ -32,7 +32,7 @@ class DriverFactory
         }
 
         // If not a Lockdown driver it means it is a custom driver
-        $driver = $this->guard->driver;
+        $driver = $this->guard->get('driver');
         if (class_exists($driver)) {
             return new $driver($arguments);
         }
@@ -48,7 +48,8 @@ class DriverFactory
      */
     private function resolveDriverPath()
     {
-        return sprintf('\\%s\\Drivers\\%sDriver', __NAMESPACE__, ucfirst($this->guard->driver));
+        $driverClassName = ucfirst($this->guard->get('driver'));
+        return sprintf('\\%s\\Drivers\\%sDriver', __NAMESPACE__, $driverClassName);
     }
 
     /**
@@ -58,6 +59,6 @@ class DriverFactory
      */
     private function resolveDriverArguments()
     {
-        return $this->guard->arguments ?? null;
+        return $this->guard->except('driver')->toArray() ?? null;
     }
 }

--- a/src/DriverFactory.php
+++ b/src/DriverFactory.php
@@ -4,14 +4,16 @@ namespace Leuverink\Lockdown;
 
 use Leuverink\Lockdown\Drivers\Driver;
 use Leuverink\Lockdown\Exceptions\LockdownDriverNotFound;
+use Illuminate\Support\Fluent;
 
 class DriverFactory
 {
+
     private $guard;
 
-    public function __construct(object $guard)
+    public function __construct($guard)
     {
-        $this->guard = $guard;
+        $this->guard = new Fluent($guard);
     }
 
     /**

--- a/src/Drivers/ConfigDriver.php
+++ b/src/Drivers/ConfigDriver.php
@@ -12,7 +12,6 @@ class ConfigDriver extends Driver
      */
     public function passesAuthentication($user, $password) : bool
     {
-
         $passes = collect($this->users)->filter(function ($authenticatable) use ($user, $password) {
             return $authenticatable['user'] === $user &&
                    $authenticatable['password'] === $password;

--- a/src/Drivers/ConfigDriver.php
+++ b/src/Drivers/ConfigDriver.php
@@ -12,7 +12,8 @@ class ConfigDriver extends Driver
      */
     public function passesAuthentication($user, $password) : bool
     {
-        $passes = $this->arguments->filter(function ($authenticatable) use ($user, $password) {
+
+        $passes = collect($this->users)->filter(function ($authenticatable) use ($user, $password) {
             return $authenticatable['user'] === $user &&
                    $authenticatable['password'] === $password;
         })->isNotEmpty();

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -24,7 +24,7 @@ class DatabaseDriver extends Driver
         );
 
         $user = DB::table(config('lockdown.table'))
-                    ->whereGroup($this->arguments->get('group'))
+                    ->whereGroup($this->group)
                     ->whereUser($user)
                     ->first();
 

--- a/src/Drivers/Driver.php
+++ b/src/Drivers/Driver.php
@@ -8,16 +8,10 @@ use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 abstract class Driver implements DriverContract
 {
-    /**
-     * All optional arguments passed via the guard config.
-     *
-     * @var Collection
-     */
-    protected $arguments;
 
-    public function __construct($arguments)
+    public function __construct($properties)
     {
-        $this->arguments = new Collection($arguments);
+        $this->setObjectProperties($properties);
     }
 
     /**
@@ -45,5 +39,18 @@ abstract class Driver implements DriverContract
         );
 
         return $passes;
+    }
+
+    /**
+     * Set the instance public properties dynamically
+     *
+     * @param array$properties
+     * @return void
+     */
+    final private function setObjectProperties(array $properties)
+    {
+        foreach ($properties as $name => $value) {
+            $this->$name = $value;
+        }
     }
 }

--- a/src/Drivers/Driver.php
+++ b/src/Drivers/Driver.php
@@ -44,7 +44,7 @@ abstract class Driver implements DriverContract
     /**
      * Set the instance public properties dynamically
      *
-     * @param array$properties
+     * @param array $properties
      * @return void
      */
     final private function setObjectProperties(array $properties)

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -16,9 +16,9 @@ class ConfigurationTest extends TestCase
         $this->assertNotNull($lock->config->get('guards'));
         $this->assertNotNull($lock->config->get('guards.config'));
         $this->assertNotNull($lock->config->get('guards.config.driver'));
-        $this->assertNotNull($lock->config->get('guards.config.arguments'));
+        $this->assertNotNull($lock->config->get('guards.config.users'));
         $this->assertNotNull($lock->config->get('guards.database'));
         $this->assertNotNull($lock->config->get('guards.database.driver'));
-        $this->assertNotNull($lock->config->get('guards.database.arguments.group'));
+        $this->assertNotNull($lock->config->get('guards.database.group'));
     }
 }

--- a/tests/Unit/DriverFactoryTest.php
+++ b/tests/Unit/DriverFactoryTest.php
@@ -36,7 +36,7 @@ class DriverFactoryTest extends TestCase
     public function it_throws_exception_when_driver_not_found()
     {
         // arrange
-        $this->guard->driver = 'non-existing-driver-name';
+        $this->guard['driver'] = 'non-existing-driver-name';
         $factory = new DriverFactory($this->guard);
 
         // act

--- a/tests/Unit/DriverFactoryTest.php
+++ b/tests/Unit/DriverFactoryTest.php
@@ -16,7 +16,7 @@ class DriverFactoryTest extends TestCase
     {
         parent::setUp();
 
-        $this->guard = (object) config('lockdown.guards.config');
+        $this->guard = config('lockdown.guards.config');
     }
 
     /** @test */


### PR DESCRIPTION
# Refactored the driver arguments to be assigned dynamically

Argument unpacking doesn't work with php yet. which is a bummer really. This is why driver arguments are passed as an array which are then dynamically assigned to the driver object.

Benefits of this approach are:

- Configuration is less nested.
- More intuitive custom diver workflow

# Important

Side effect is that driver arguments in the config no longer need to be passed inside a 'arguments' clause. All keys except the driver definition are available as public properties within the driver object. This is a backwards compatibility breaking change and thus the MAJOR version should be bumped.